### PR TITLE
fix: Define bypass_off_time as global

### DIFF
--- a/bin/cfc.py
+++ b/bin/cfc.py
@@ -442,7 +442,7 @@ def callback_sensor(var, value):
     
 
 def main():
-    global mqtt_topic, client, debug, loglevel, logfile, _LOGGER, search, unknown, boost_mode_time, ventmode_stop_supply_fan_time, ventmode_stop_exhaust_fan_time, bypass_on_time, comfoconnect
+    global mqtt_topic, client, debug, loglevel, logfile, _LOGGER, search, unknown, boost_mode_time, ventmode_stop_supply_fan_time, ventmode_stop_exhaust_fan_time, bypass_on_time, bypass_off_time, comfoconnect
     
     connected_flag = 0
     loglevel=logging.ERROR


### PR DESCRIPTION
The on_message function tries to access this variable as a global, but this leads to a NameError

```
Exception in thread Thread-1 (_thread_main):
Traceback (most recent call last):
File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
self.run()
File "/usr/lib/python3.11/threading.py", line 975, in run
self._target(*self._args, **self._kwargs)
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3591, in _thread_main
self.loop_forever(retry_first_connection=True)
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1756, in loop_forever
rc = self._loop(timeout)
^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1164, in _loop
rc = self.loop_read()
^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1556, in loop_read
rc = self._packet_read()
^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 2439, in _packet_read
rc = self._packet_handle()
^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3033, in _packet_handle
return self._handle_publish()
^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3327, in _handle_publish
self._handle_on_message(message)
File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3570, in _handle_on_message
on_message(self, self._userdata, message)
File "/opt/loxberry/bin/plugins/comfoconnect/cfc.py", line 348, in on_message
comfoconnect.cmd_rmi_request(b'\x84\x15\x02\x01\x00\x00\x00\x00' + bypass_off_time + b'\x00\x00\x02')
^^^^^^^^^^^^^^^
NameError: name 'bypass_off_time' is not defined. Did you mean: 'bypass_on_time'?
```