### PR TITLE
Zeitvorgaben auf 4 Byte

### DIFF
--- a/bin/cfc.py
+++ b/bin/cfc.py
@@ -40,26 +40,15 @@ sensors_expected = len(sensor_data)
 sensorwatch_enabled = False
 sensorwatch_timeout_sec = 60
 
-# MQTT topic reporting whether the ventilation unit has stopped sending sensor data:
-# "1" = timeout detected, "0" = data is flowing (or monitoring is switched off).
-#
-# Without this the timeout was only ever visible in the plugin's own web page, or
-# indirectly through the plugin restarting itself - so with monitoring enabled but
-# automatic restart switched off, nothing outside the browser noticed at all. As a
-# retained topic it can be wired straight into Loxone like any other sensor value.
-#
-# Published only on change (plus once per MQTT (re)connect, see on_connect) rather
-# than every second, so it doesn't add a message per second to the broker forever.
+# Meldet per MQTT, ob die Anlage noch Sensorwerte liefert. 1 = seit der
+# eingestellten Zeit nichts mehr empfangen, 0 = laeuft wieder.
 SENSORWATCH_TOPIC = "SENSOR_TIMEOUT"
 
-# Last value published to SENSORWATCH_TOPIC. None means "nothing published yet on
-# this MQTT connection" and forces the next evaluation to publish, whatever it finds.
+# Zuletzt auf SENSORWATCH_TOPIC gesendeter Wert. None = noch nichts gesendet.
 sensorwatch_published = None
 
-# Set by on_connect()/on_disconnect() - read by the status-writer thread. paho's own
-# reconnect (client.reconnect_delay_set()) already handles recovering the MQTT link by
-# itself; this flag only exists so the status file/webfrontend can show whether it is
-# currently up, it doesn't trigger any reconnect logic of its own.
+# Zustand der MQTT-Verbindung, gesetzt von on_connect/on_disconnect und vom
+# Status-Thread gelesen.
 mqtt_connected = False
 mqtt_last_change = None
 
@@ -120,13 +109,11 @@ def _abonniere(client, name):
 statusfile = None
 
 def thread_sicher(fn):
-    """Verhindert, dass ein Fehler in einem Rueckruf den fremden Thread mitreisst.
+    """Faengt Fehler in einem MQTT-Rueckruf ab.
 
-    Die MQTT-Rueckrufe unten werden von paho im eigenen Netzwerk-Thread aufgerufen.
-    Eine durchgereichte Ausnahme beendet dort die Schleife - die MQTT-Seite ist
-    danach tot, waehrend das Plugin weiterlaeuft und nach aussen gesund aussieht:
-    Sensorwerte gehen nicht mehr raus, Befehle kommen nicht mehr an, und im Log
-    steht nichts, was darauf hindeutet.
+    paho ruft diese Funktionen im eigenen Netzwerk-Thread auf. Eine
+    durchgereichte Ausnahme wuerde dort die Schleife beenden - die MQTT-Seite
+    waere danach still tot.
     """
     @functools.wraps(fn)
     def sicher(*args, **kwargs):
@@ -219,14 +206,8 @@ def on_connect(client, userdata, flags, rc):
 def on_disconnect(client, userdata, rc):
     global mqtt_connected, mqtt_last_change, mqtt_abbrueche, mqtt_letzter_abbruch
 
-    # Closing the session #############################################################################################
-    # NOTE: rc here is NOT a CONNACK code - mqtt.connack_string(rc) used to be called
-    # on it, which produces a technically-valid-looking but WRONG message (e.g. rc=1
-    # prints "unacceptable protocol version" - a CONNACK-only meaning - even though
-    # every single one of these disconnects was directly preceded by a genuinely
-    # successful CONNACK 0/Accepted just milliseconds earlier). paho's own docs say
-    # this rc is an internal MQTTErrorCode it converts to for MQTT v3.x, not
-    # something the broker sent - error_string() is the correct lookup here.
+    # rc ist hier kein CONNACK-Code, sondern der Grund der Trennung:
+    # 0 = von uns veranlasst, alles andere ein Abbruch.
     if rc==0:
         _LOGGER.info("MQTT-Verbindung sauber getrennt.")
     else:
@@ -255,11 +236,8 @@ def on_message(client, userdata, msg):
         # waere er verarbeitet worden - gerade beim Suchen nach "warum passiert
         # nichts" waere das die falsche Faehrte.
         letzte_befehle[kurz] = (value, time.time(), fehlertext(e))
-        # A malformed/empty MQTT payload (e.g. an empty retained message, or a value
-        # that isn't a valid number where int(value) is expected) must never crash
-        # this callback: paho runs on_message on its network thread, and an uncaught
-        # exception here kills that thread - the plugin then silently stops reacting
-        # to MQTT until it is manually restarted. Log and ignore instead.
+        # Ein unbrauchbarer Payload darf diesen Rueckruf nicht abbrechen: paho ruft ihn
+        # im eigenen Thread auf, eine Ausnahme wuerde die MQTT-Seite stilllegen.
         _LOGGER.error("Fehler bei Verarbeitung von MQTT %s = '%s': %s" % (topic, value, fehlertext(e)))
 
 def _dispatch_message(topic, value):
@@ -676,21 +654,7 @@ away_active_published = None
 away_remaining_published = None
 
 def seconds_to_timerfield(seconds):
-    """Baut das 4-Byte-Zeitfeld der 0x84-Befehle (Sekunden, little-endian).
-
-    Nachgerechnet an den dokumentierten Beispielen: Boost "10 Minuten" ist
-    58020000 = 600, Bypass "1 Stunde" ist 100e0000 = 3600.
-
-    Vier echte Bytes. Frueher wurde hier ein 2-Byte-Feld plus zwei angehaengte
-    Nullbytes verwendet - das konnte nur 65535 Sekunden abbilden (gut 18 Stunden)
-    und warf darueber einen OverflowError, woraufhin die betroffene Zeit still auf
-    ihrem alten Wert stehen blieb. Die Zehnder-App erlaubt fuer Boost aber 24
-    Stunden, also 86400 Sekunden.
-
-    Die erzeugte Bytefolge ist fuer alle Werte bis 65535 identisch mit der
-    frueheren - nachgerechnet fuer 0, 1, 600, 900, 3600, 7200, 43200 und 65535.
-    Der Umstieg aendert also an funktionierenden Befehlen kein einziges Bit.
-    """
+    """Wandelt Sekunden in das 4-Byte-Zeitfeld der 0x84-Befehle (little-endian)."""
     seconds = int(seconds)
     if seconds < 0:
         seconds = 0
@@ -699,16 +663,9 @@ def seconds_to_timerfield(seconds):
     return seconds.to_bytes(4, byteorder='little')
 
 def callback_alarm(node_id, errors):
-    """Veroeffentlicht die Stoerungsmeldungen der Anlage per MQTT.
+    """Veroeffentlicht die von der Anlage gemeldeten Stoerungen per MQTT.
 
-    Wird von comfoconnect.py aufgerufen, sobald eine CnAlarmNotification eintrifft -
-    also ereignisgesteuert, nicht gepollt. Die Anlage schickt bei jeder Aenderung den
-    kompletten aktuellen Fehlerstand, deshalb kann hier direkt ueberschrieben werden,
-    ohne alte Meldungen mitfuehren zu muessen.
-
-    ERROR_COUNT ist fuer die Logik in Loxone gedacht (0 = alles gut), ERROR_TEXT fuer
-    die Anzeige. Beide retained, damit ein neu verbundener Client den aktuellen Stand
-    sofort sieht statt bis zur naechsten Aenderung im Dunkeln zu tappen.
+    Sendet ERROR_COUNT und ERROR_TEXT; ohne anstehende Fehler 0 und Leerstring.
     """
     try:
         anzahl = len(errors)
@@ -721,22 +678,9 @@ def callback_alarm(node_id, errors):
         _LOGGER.error("Konnte Störungsmeldung nicht per MQTT senden: " + fehlertext(e))
 
 def poll_away_loop():
-    """Holt den Abwesenheits-Zustand zyklisch ab und veroeffentlicht ihn per MQTT.
+    """Fragt den Abwesenheitszustand zyklisch ab und veroeffentlicht ihn.
 
-    Laeuft in einem EIGENEN Thread, nicht in write_status_loop(): Ein RMI-Aufruf
-    kann im schlechtesten Fall bis zum Antwort-Timeout haengen, und das wuerde dort
-    das sekuendliche Schreiben der Statusdatei blockieren - die Weboberflaeche
-    zeigte dann faelschlich veraltete Daten an.
-
-    Antwortformat von 0x83 (14 Byte), abgeleitet aus aiocomfoconnect:
-
-        01 00000000 55020000 53020000 00
-        ^^          ^^^^^^^^ ^^^^^^^^
-        |           gesamt   Rest (jeweils Sekunden, little-endian)
-        aktiv (00 = nein, 01 = ja)
-
-    Wie bei allen Diagnosefunktionen hier gilt: Fehler werden geschluckt, das
-    darf das eigentliche Plugin niemals mit herunterreissen.
+    Laeuft in einem eigenen Thread, weil die RMI-Abfrage blockiert.
     """
     global away_active_published, away_remaining_published
 
@@ -779,22 +723,10 @@ def send_away(seconds):
     return cmd
 
 def sensorauswahl_anwenden(pcfg):
-    """Liest, welche Sensoren in den Einstellungen abgewählt wurden.
+    """Liest aus der Konfiguration, welche Sensoren abgewaehlt sind.
 
-    Gibt die Menge der abgewaehlten pdids zurueck. Der Katalog in mqtt_data.py ist
-    und bleibt die einzige Quelle dafuer, WELCHE Sensoren es gibt - hier steht nur,
-    welche davon der Benutzer nicht moechte.
-
-    Bewusst keine Moeglichkeit, eigene pdids zu ergaenzen: Der Rohwert wird nach
-    Byte-Laenge dekodiert, nicht nach PDO-Typ (siehe _handle_rpdo_notification in
-    comfoconnect.py). Vierbyte-Werte kaemen als Hex-Zeichenkette an, und
-    vorzeichenlose Werte oberhalb von 127 bzw. 32767 kippten ins Negative. Ein
-    neuer Sensor braucht deshalb ohnehin eine Codeaenderung - dann kann er auch
-    gleich richtig in mqtt_data.py stehen.
-
-    Absichtlich nachsichtig: Ein unbrauchbarer Eintrag wird uebersprungen und
-    protokolliert, statt den Start zu verhindern. Ein Tippfehler in der Auswahl darf
-    nicht die ganze Lueftungssteuerung lahmlegen.
+    Liefert die Menge der abgewaehlten pdids. Unbrauchbare Eintraege werden
+    uebersprungen und protokolliert, damit ein Tippfehler nicht den Start verhindert.
     """
     abschnitt = pcfg.get('SENSORS') or {}
 
@@ -1055,25 +987,18 @@ class SnapshotSchreiber(logging.Handler):
 
 
 def fehlertext(e):
-    """Beschreibt eine Ausnahme lesbar - auch wenn sie gar keinen Text hat.
+    """Liefert eine lesbare Beschreibung einer Ausnahme.
 
-    Die Protokoll-Ausnahmen dieser Bibliothek (PyComfoConnectNotAllowed,
-    ...NotExist, ...BadRequest und die uebrigen) sind reine Markierungsklassen
-    ohne Meldung, str() liefert dort einen LEEREN String. Wer sie nur mit str(e)
-    protokolliert, schreibt "ging nicht: " ins Log und verschweigt die Ursache -
-    genau so geschehen bei der Abwesenheitsabfrage, wo 375 Meldungen ohne jede
-    Begruendung im Log standen, obwohl der Grund (NOT_ALLOWED) eine Zeile darueber
-    stand.
+    Die Ausnahmen der Protokollschicht tragen meist keinen Text - dann bleibt
+    nur der Klassenname.
     """
     text = str(e)
     return "%s: %s" % (type(e).__name__, text) if text else type(e).__name__
 
 def to_seconds(value):
-    """Wandelt eine MQTT-Nutzlast in ganze Sekunden.
+    """Wandelt eine Zeitangabe in ganze Sekunden.
 
-    Ueber float() statt direkt int(): Loxone schickt Zahlen regelmaessig in
-    Fliesskommaschreibweise ("240.0"), und int("240.0") wirft ValueError - das
-    landete frueher als Fehlermeldung im Log statt als gesetzter Wert.
+    Loxone sendet Zahlen haeufig als "600.0"; int() allein wuerde daran scheitern.
     """
     return int(float(value))
 
@@ -1082,14 +1007,9 @@ def on_log(client, userdata, level, buf):
     _LOGGER.debug("Paho: " + buf)
 
 def callback_sensor(var, value):
-    # No gating on registration progress here: every value that arrives is published
-    # straight away, including during the initial registration sweep and during the
-    # re-registration after a reconnect. A sensor only ever sends data once the bridge
-    # has confirmed ITS OWN subscription, so an early value is a real, current reading -
-    # withholding it just delays fresh data reaching Loxone for no benefit. On real
-    # hardware the whole 50-sensor sweep completes in well under a second anyway.
-    # comfoconnect.sensors_ready still exists, but purely to drive the status display
-    # (see write_status_loop()/index.cgi), not to block anything.
+    # Jeder eintreffende Wert wird sofort veroeffentlicht, auch waehrend der
+    # Anmeldung. Ein Sensor sendet erst, nachdem die Anlage sein Abonnement
+    # bestaetigt hat - der Wert ist also gueltig.
     if (var == 81 or var == 82 or var == 86 or var == 87):
         value=int(to_little(value), base=16)
         if value == 4294967295:
@@ -1128,20 +1048,10 @@ def callback_sensor(var, value):
     
 
 def write_status_loop():
-    """Periodically persist a small health-status JSON to statusfile (ramdisk).
+    """Schreibt sekuendlich die Statusdatei fuer die Weboberflaeche.
 
-    Runs in its own daemon thread. Deliberately does not import/depend on the
-    connection thread's internals beyond reading comfoconnect's plain, cheap
-    in-memory timestamps (see comfoconnect.py: last_alive_ping/last_keepalive_ok/
-    last_sensor_data) - it just samples and writes them every 1s. This is a
-    nice-to-have diagnostic feature: any error here is logged and swallowed, it
-    must never be able to take down the actual plugin.
-
-    1s instead of the original 5s: this is a plain JSON write to a ramdisk
-    (tmpfs), not real disk I/O, so there's no SD-card-wear concern to weigh
-    against faster updates - the only real cost is CPU for a tiny JSON dump,
-    which is negligible. Combined with the shorter webfrontend poll interval,
-    this brings worst-case status staleness down from ~15s to ~3s.
+    Laeuft in einem eigenen Thread. Fehler werden protokolliert und verschluckt -
+    eine Anzeigefunktion darf den Betrieb nicht gefaehrden.
     """
     while True:
         try:
@@ -1265,18 +1175,7 @@ def write_status_loop():
 
 
 def publish_sensorwatch_state():
-    """Publishes SENSORWATCH_TOPIC whenever the sensor-data timeout state changes.
-
-    Bewusst dieselbe Auswertung wie getStatus() in index.cgi: Timeout nur melden,
-    wenn die Überwachung eingeschaltet ist UND bereits Sensoren registriert waren
-    (sonst würde direkt nach dem Start ein Timeout gemeldet, bevor überhaupt Daten
-    kommen konnten). Sind beide Bedingungen erfüllt, aber es kam noch nie ein Wert,
-    gilt das ebenfalls als Timeout - genau wie im Webfrontend.
-
-    Ist die Überwachung ausgeschaltet, wird konsequent "0" veröffentlicht statt gar
-    nichts: das Topic ist retained, ein hängengebliebenes "1" von früher würde sonst
-    für immer eine Störung vortäuschen, die niemand mehr auswertet.
-    """
+    """Veroeffentlicht SENSOR_TIMEOUT, wenn keine Sensordaten mehr eintreffen."""
     global sensorwatch_published
 
     if not comfoconnect or not mqtt_connected:
@@ -1464,22 +1363,9 @@ def main():
             json.dump(pcfg, outfile, ensure_ascii=True, indent=4)
         exit(0)
         
-    # paho-mqtt >= 2.0 requires an explicit callback_api_version as first argument and
-    # changed the on_connect/on_message/... callback signatures. All callbacks in this
-    # file (on_connect, on_disconnect, on_message, on_publish, ...) use the legacy (v1)
-    # signatures, so we explicitly request VERSION1 when it is available. This keeps the
-    # plugin working unchanged on systems that still ship paho-mqtt 1.x (e.g. LoxBerry 3,
-    # Debian bullseye's python3-paho-mqtt 1.5.1) as well as on systems where paho-mqtt 2.x
-    # is installed (e.g. some LoxBerry 4 setups).
-    # Unique per process (PID suffix), not a fixed "ComfoConnect" - during a
-    # "Speichern"-triggered restart, the old and new cfc.py processes can briefly
-    # overlap (see wait_for_cfc_exit() in wrapper.pl). Two MQTT clients connecting
-    # with the SAME client_id make the broker evict whichever one is already
-    # connected every time the other (re)connects - observed in practice as a
-    # rapid connect/disconnect loop for several seconds after every restart (each
-    # disconnect misleadingly logged, before the on_disconnect fix above, as
-    # "unacceptable protocol version"). A unique ID per process avoids the
-    # collision entirely, regardless of how long any overlap lasts.
+    # paho-mqtt ab 2.0 verlangt die Angabe der Rueckruf-Schnittstelle. Wir nutzen
+    # weiterhin die alte (VERSION1); die Abfrage haelt aeltere paho-Versionen
+    # lauffaehig, die das Argument nicht kennen.
     mqtt_client_id = "ComfoConnect-%d" % os.getpid()
     if hasattr(mqtt, "CallbackAPIVersion"):
         # paho-mqtt >= 2.0
@@ -1501,7 +1387,8 @@ def main():
         
     bridge = bridge_discovery(device_ip, search)
 
-    # Connect to the bridge
+    # Verbindungsaufbau mit mehreren Versuchen: Direkt nach einem Neustart des
+    # LoxBerry ist das Netz manchmal noch nicht bereit.
     try:
         _LOGGER.info("Connecting to the " + local_name + " - PIN: " + str(pin))
         comfoconnect = ComfoConnect(bridge, local_uuid, local_name, pin)
@@ -1512,70 +1399,36 @@ def main():
     comfoconnect.callback_sensor = callback_sensor
     comfoconnect.callback_alarm = callback_alarm
 
-    # Graceful shutdown on SIGTERM (wrapper.pl's plain `pkill -f cfc.py`, used both by
-    # a "Speichern"-triggered restart and by the watchdog). Without this the process
-    # just dies instantly with no warning to the bridge - observed in practice: the
-    # bridge then keeps the old session "alive" for several seconds ("resumed: true"
-    # on the next StartSessionConfirm), replaying a backlog of leftover messages tied
-    # to the old session before it gets around to confirming the NEW process's
-    # StartSessionRequest. Explicitly closing the session here lets the next startup
-    # connect cleanly and immediately instead of eating into its own connect timeout.
-    # Registered here (not earlier) so `comfoconnect` and `client` already exist for
-    # every SIGTERM this could plausibly catch - a signal arriving in the brief window
-    # before this line has nothing to clean up yet anyway (no session established).
+    # Sauberes Herunterfahren bei SIGTERM (wrapper.pl beendet mit pkill).
+    # Meldet die Sitzung bei der Anlage ab, damit der naechste Start nicht auf eine
+    # noch offene Sitzung trifft.
     def handle_sigterm(signum, frame):
         _LOGGER.info("SIGTERM empfangen - fahre sauber herunter (melde Session bei der Zehnder-Box ab)...")
 
-        # Tell the background threads this disconnect is intentional BEFORE sending
-        # CloseSessionRequest below - otherwise, once the bridge closes the socket in
-        # response (typically within milliseconds), the message thread has no way to
-        # tell that apart from a real, unexpected connection loss: it would log a
-        # misleading "connection was broken, we will try to reconnect" warning and
-        # start a reconnect attempt that os._exit() below cuts off anyway.
-        # mark_disconnecting() only sets flags, it doesn't block (unlike
-        # comfoconnect.disconnect()), so it's safe to call from this handler.
+        # Erst die Threads informieren, dann abmelden - sonst werten sie das Schliessen
+        # der Verbindung als Ausfall und starten einen Wiederaufbau.
         comfoconnect.mark_disconnecting()
 
         try:
             if comfoconnect.is_connected():
-                # Plain 5s default like every other command - no special short timeout
-                # here. In practice this never waits at all: the bridge answers a
-                # CloseSessionRequest by simply closing the TCP socket rather than
-                # sending a CloseSessionConfirm, and the message thread turns that into
-                # an immediate wake-up (see _CONNECTION_LOST in comfoconnect.py) instead
-                # of letting the caller sit out its timeout. Measured end-to-end in the
-                # log: request sent and process fully shut down within ~5ms. The timeout
-                # only matters if the bridge neither answers nor drops the connection -
-                # and takeover=True on the next startup covers that case anyway.
+                # Ueblicher Zeitrahmen. In der Praxis wartet das nie: Die Anlage beantwortet die
+                # Abmeldung, indem sie die Verbindung schliesst.
                 comfoconnect.cmd_close_session()
                 _LOGGER.info("Session bei der Zehnder-Box abgemeldet.")
         except OSError as e:
-            # The bridge tends to just close the TCP connection right after
-            # processing this request instead of sending an explicit
-            # CloseSessionConfirm back first - the connection dying WHILE we're
-            # waiting is a pretty strong sign the request was received and acted
-            # on (the request itself did get sent - if it hadn't, is_connected()
-            # above would already be False). Nothing more to verify here, and it's
-            # not an actual problem, so INFO rather than WARNING.
+            # Die Anlage schliesst die Verbindung meist sofort nach der Abmeldung. Dass sie
+            # dabei wegbricht, ist also kein Fehler.
             _LOGGER.info("CloseSessionRequest gesendet, Bridge hat die Verbindung direkt danach getrennt (normal): " + str(e))
         except ValueError as e:
-            # Different from the OSError case above: this is a PLAIN timeout - the
-            # connection itself did NOT drop, the bridge just never answered within
-            # the standard reply timeout. Unlike the OSError case, we genuinely don't know
-            # whether the session actually got closed - could still be sitting open
-            # on the bridge's side. takeover=True on the next startup is the safety
-            # net either way, so there's nothing more to do here, but the log
-            # shouldn't claim "normal"/success for something it can't verify.
+            # Hier kam gar keine Antwort und die Verbindung steht noch - ob die Sitzung
+            # wirklich geschlossen wurde, ist offen. takeover beim naechsten Start regelt es.
             _LOGGER.warning("CloseSessionRequest gesendet, aber keine Bestätigung erhalten (Timeout) - Session evtl. noch offen, takeover beim nächsten Start übernimmt das: " + str(e))
         except Exception as e:
             _LOGGER.warning("Konnte Session bei der Zehnder-Box nicht sauber schließen: " + fehlertext(e))
 
         try:
-            # disconnect() before loop_stop(): sends the clean DISCONNECT packet
-            # while the network thread is still running to actually flush it, then
-            # stop the thread. Doing it in the other order risks the DISCONNECT
-            # never truly leaving the socket, in which case the broker only notices
-            # via the TCP connection dropping - functionally similar, but less clean.
+            # Erst abmelden, dann den Netzwerk-Thread stoppen - sonst verlaesst das
+            # DISCONNECT-Paket den Socket womoeglich nicht mehr.
             client.disconnect()
             client.loop_stop()
         except Exception:
@@ -1598,18 +1451,9 @@ def main():
 
         _LOGGER.info("Sauber heruntergefahren.")
 
-        # NOT sys.exit(0): by the time SIGTERM can arrive here, main() has usually
-        # already returned and the interpreter is already inside its own shutdown
-        # sequence (threading._shutdown(), waiting for the non-daemon connection
-        # thread to finish - that's what has kept the process alive this whole
-        # time). Raising SystemExit via sys.exit() from a signal handler firing in
-        # the middle of that produces a harmless but ugly "Exception ignored in...
-        # SystemExit: 0" traceback in the log. os._exit() terminates the process
-        # immediately at the OS level, skipping Python's normal
-        # exception-based/atexit shutdown machinery entirely - safe here since
-        # everything worth cleaning up (the bridge session, the MQTT connection)
-        # was already handled explicitly above; there's nothing left for Python's
-        # own shutdown to do that we need.
+        # os._exit statt sys.exit: Zu diesem Zeitpunkt laeuft bereits Pythons eigene
+        # Beendigung. Ein SystemExit daraus erzeugte nur einen irrefuehrenden Traceback;
+        # aufzuraeumen gibt es nichts mehr.
         os._exit(0)
 
     signal.signal(signal.SIGTERM, handle_sigterm)
@@ -1665,11 +1509,8 @@ def main():
             if attempt >= bridge_connect_attempts:
                 _LOGGER.exception(str(e))
                 _LOGGER.critical("Not connected to bridge nach %d Versuchen" % bridge_connect_attempts)
-                # os._exit(), not exit(): comfoconnect.connect() may have already started
-                # the (non-daemon) connection thread on an earlier attempt even though
-                # this last one failed (see connect()'s "didn't reply on time" case) - a
-                # plain exit(1) would then just hang forever waiting for that thread to
-                # finish instead of actually terminating the process.
+                # os._exit statt exit: Der Verbindungs-Thread laeuft moeglicherweise schon und
+                # wuerde den Prozess sonst am Leben halten.
                 os._exit(1)
             _LOGGER.warning("Verbindung zur Bridge fehlgeschlagen (Versuch %d/%d), erneuter Versuch: %s" % (attempt, bridge_connect_attempts, fehlertext(e)))
             time.sleep(2)
@@ -1723,19 +1564,9 @@ def main():
             _LOGGER.info("Register Sensor: %d" % x + " Sensorname: " + sensor_data[x]['NAME'])
 
         except OSError as e:
-            # Connection genuinely gone mid-burst - no point continuing THIS sweep, but
-            # unlike the cases above, this is exactly the situation
-            # _connection_thread_loop() already exists to handle: it independently
-            # notices the same connection loss (via the message thread) and keeps
-            # retrying reconnect + re-registration in the background, indefinitely,
-            # without any help from here. Restarting the whole process would just
-            # reinvent that same recovery a layer higher up, for no benefit - so hand
-            # off instead of exiting. The one thing it needs from us: the sensors we
-            # hadn't gotten to yet aren't in comfoconnect.sensors (register_sensor()
-            # only adds a sensor there on SUCCESS), and _connection_thread_loop() only
-            # ever re-registers what's in there - so pre-remember them here, keyed
-            # exactly like register_sensor() itself would, or they'd silently never get
-            # attempted at all once the reconnect succeeds.
+            # Verbindung mitten in der Anmeldung verloren. Der Wiederaufbau im Hintergrund
+            # uebernimmt - die noch nicht versuchten Sensoren werden hier vorgemerkt, sonst
+            # wuerden sie dabei uebergangen.
             _LOGGER.warning(
                 "Verbindung beim Registrieren verloren (%d von %d Sensoren noch offen): %s - der "
                 "automatische Reconnect übernimmt jetzt, kein Neustart des Prozesses nötig." %
@@ -1775,20 +1606,12 @@ def main():
         )
 
     if not connection_lost:
-        # This first sweep runs here, in cfc.py's main thread, not in comfoconnect.py's
-        # _connection_thread_loop() (which only handles LATER reconnects) - so it has
-        # to set sensors_ready itself. From here on, every subsequent disconnect/
-        # reconnect clears and re-sets this flag automatically (see
-        # _connection_thread_loop()). If connection_lost is True, sensors_ready stays
-        # False and THAT loop sets it once its own reconnect sweep succeeds instead.
+        # Dieser erste Durchlauf laeuft im Hauptthread; spaetere Wiederholungen
+        # uebernimmt der Verbindungs-Thread.
         comfoconnect.sensors_ready = True
         _LOGGER.info("Sensor-Registrierung abgeschlossen: %d von %d Sensoren registriert." % (len(comfoconnect.sensors_confirmed), len(sensor_ids)))
 
-    # Diagnostic-only calls - wrapped so a connection hiccup right at this moment
-    # (e.g. still mid-reconnect after the loop above gave up early) can't crash the
-    # main thread with an uncaught exception. Not fatal to the plugin either way
-    # (the background connection/message threads keep running regardless), but an
-    # uncaught traceback here is needless noise and skips the remaining diagnostics.
+    # Reine Diagnoseabfragen - ein Aussetzer dabei darf den Start nicht verhindern.
     try:
         # VersionRequest
         version = comfoconnect.cmd_version_request()

--- a/bin/pycomfoconnect/comfoconnect.py
+++ b/bin/pycomfoconnect/comfoconnect.py
@@ -22,15 +22,9 @@ DEFAULT_PIN = 0
 
 _LOGGER = logging.getLogger('comfoconnect')
 
-# Sentinel pushed onto self._queue by _message_thread_loop the moment it detects
-# the connection is dead (BrokenPipeError/ConnectionResetError/ConnectionError).
-# Without this, a call blocked in _get_reply()'s self._queue.get(timeout=5) has no
-# way to find out the connection already died in the *other* thread - it just sits
-# there uselessly until its own independent 5s timeout expires, which is why the
-# log used to show the "connection was reseted" warning followed several seconds
-# later by a seemingly unrelated "Timeout waiting for response" error for a
-# message that could obviously never arrive anymore. Pushing this sentinel wakes
-# the waiter up immediately instead.
+# Wird in die Warteschlange gelegt, sobald der Nachrichten-Thread den Verlust
+# der Verbindung bemerkt. Weckt einen Wartenden sofort, statt ihn in sein
+# Zeitlimit laufen zu lassen.
 _CONNECTION_LOST = object()
 
 # Sensor variable size
@@ -160,31 +154,14 @@ class ComfoConnect(object):
 
         self._queue = queue.Queue()
 
-        # References we've personally given up on (a plain client-side timeout in
-        # _get_reply(), see there) - a confirm for one of these that shows up later
-        # is permanently orphaned: whoever originally sent that request has already
-        # moved on (retried with a new reference, or given up for good), so nobody
-        # will ever be waiting for it again. Without tracking this, such a confirm
-        # gets deferred, handed back to self._queue, picked up again by the NEXT
-        # unrelated wait, found not to match either, deferred again... forever, for
-        # the remaining lifetime of the connection - one harmless but permanently
-        # recurring "Ignoring confirm..." log line per subsequent _command() call.
-        # Bounded in practice: only grows on a timeout (rare), and is cleared on
-        # every reconnect along with self._queue itself.
+        # Referenzen, deren Antwort wir nicht mehr erwarten (Zeitlimit abgelaufen).
+        # Trifft sie doch noch ein, wird sie verworfen - sonst kreiste sie dauerhaft
+        # in der Warteschlange.
         self._abandoned_references = set()
 
-        # Guards reference-number generation and the actual socket write in
-        # _command() (see there). Two different threads legitimately call _command()
-        # concurrently in normal operation - the main thread doing the startup sensor
-        # registration burst / diagnostic queries, and the background message thread
-        # sending its periodic cmd_keepalive() - and without this lock both the
-        # "self._reference += 1" read-modify-write and the raw socket.sendall() call
-        # are unsynchronized: two threads could hand out the SAME reference number
-        # (breaking the reference-matching in _get_reply()) or interleave their bytes
-        # on the wire while writing concurrently (corrupting the message framing).
-        # Only covers the write side, not the wait-for-reply side, so two commands can
-        # still be in flight and waiting on their own replies at the same time without
-        # blocking each other for up to 5s.
+        # Schuetzt die Vergabe der Referenznummer und das Schreiben auf den Socket.
+        # Haupt- und Nachrichten-Thread senden gleichzeitig; ohne Sperre koennten
+        # zwei Befehle dieselbe Nummer bekommen oder ihre Bytes verschraenken.
         self._command_lock = threading.Lock()
 
         self._connected = threading.Event()
@@ -195,20 +172,9 @@ class ComfoConnect(object):
 
         self.sensors = {}
 
-        # self.sensors above is really a work list of "sensors we know about and
-        # should (re-)register on every reconnect" - cfc.py pre-populates entries
-        # into it for sensors that haven't been attempted yet (so a dropped
-        # connection mid-burst doesn't lose track of them), and every reconnect's
-        # re-registration pass iterates the whole thing again regardless of
-        # whether each entry has actually been confirmed by the bridge yet. That
-        # makes len(self.sensors) meaningless as a "how many are really working
-        # right now" count - it was already at its final size before most entries
-        # were ever confirmed. This separate set only ever gains a sensor_id once
-        # the bridge has actually confirmed that specific registration (see
-        # register_sensor()), and gets reset at the start of every reconnect's
-        # re-registration pass since RPDO subscriptions don't survive a
-        # reconnect - cfc.py's status file reads this, not self.sensors, for the
-        # "X sensors active" count.
+        # Sensoren, deren Anmeldung die Anlage bestaetigt hat. Anders als self.sensors
+        # (eine Arbeitsliste fuer den Wiederaufbau) taugt das als Zaehler fuer
+        # "X Sensoren aktiv".
         self.sensors_confirmed = set()
 
         # True, solange ein laufender Verbindungsausfall bereits gemeldet und gezaehlt
@@ -247,40 +213,15 @@ class ComfoConnect(object):
             'letzter_timeout': None,
         }
 
-        # True only while a connection is up AND the (re-)registration sweep for all
-        # known sensors (self.sensors) has actually finished - False from the moment a
-        # disconnect is noticed until the next successful sweep completes.
-        #
-        # PURELY INFORMATIONAL: this drives the status display only (cfc.py's status
-        # file -> index.cgi shows "Registriere Sensoren" while it's False). It does NOT
-        # gate MQTT publishing - callback_sensor() publishes every value immediately,
-        # including during a registration sweep. A sensor only starts sending data once
-        # the bridge has confirmed its own subscription, so such a value is a real,
-        # current reading and there's no reason to withhold it.
-        #
-        # Set by _connection_thread_loop() on every (re)connect; cfc.py additionally
-        # sets it True itself after ITS OWN initial registration loop at startup
-        # completes (that first pass runs in cfc.py's main thread, not here).
+        # True, sobald alle bekannten Sensoren auf der aktuellen Verbindung angemeldet
+        # sind. Steuert nur die Statusanzeige, nicht das Veroeffentlichen.
         self.sensors_ready = False
 
-        # True once _connection_thread_loop() has noticed at least one real
-        # disconnect and is (re)connecting because of it. Guards sensors_ready so the
-        # background loop only ever touches it for a GENUINE reconnect - not for its
-        # own very first pass right after the initial connect(), which runs
-        # concurrently with cfc.py's own startup registration loop (self.sensors is
-        # still empty at that point, since register_sensor() only adds to it on
-        # success) and would otherwise hit the "nothing to (re-)register yet" branch
-        # and flip sensors_ready True within milliseconds - long before cfc.py's own
-        # sweep, or even the MQTT client, are anywhere close to ready. Observed in
-        # practice as a flood of "Fehler published, RC=4" (MQTT_ERR_NO_CONN) during
-        # every single startup.
+        # True ab dem ersten echten Verbindungsverlust. Unterscheidet den Wiederaufbau
+        # vom ersten Verbindungsaufbau, bei dem cfc.py die Sensoren selbst anmeldet.
         self._is_reconnect = False
 
-        # Heartbeat/health bookkeeping, read from the outside (cfc.py) to build a
-        # status file. These are plain timestamps (time.time(), or None until the
-        # first occurrence) updated cheaply in memory - the caller decides how often
-        # to persist them to disk, so this class doesn't need to know anything about
-        # files, paths or LoxBerry conventions.
+        # Zeitstempel fuer die Statusanzeige. Werden von cfc.py gelesen.
         self.last_alive_ping = None    # updated every message-loop iteration - proves
                                         # the message thread is looping, not hung/dead
         self.last_keepalive_ok = None  # updated when a keepalive to the bridge succeeds
@@ -339,17 +280,10 @@ class ComfoConnect(object):
             self._connection_thread.join()
 
     def mark_disconnecting(self):
-        """Flags an intended disconnection without blocking on the background threads.
+        """Markiert das bevorstehende Trennen als beabsichtigt.
 
-        disconnect() (above) does the same flag-setting but then joins the connection
-        thread - fine for a normal shutdown, but too slow/risky for cfc.py's SIGTERM
-        handler, which sends CloseSessionRequest directly via cmd_close_session() and
-        then calls os._exit() shortly after (see the handler for why). Without calling
-        this first, the message/connection threads have no way to know the socket
-        dying moments later (once the bridge processes our CloseSessionRequest) is
-        expected - they'd log a misleading "connection was broken, we will try to
-        reconnect" warning and kick off a doomed reconnect attempt during an
-        intentional shutdown. Call this before cmd_close_session().
+        Ohne das werten die Hintergrund-Threads das Schliessen der Verbindung als
+        Ausfall und beginnen einen Wiederaufbau.
         """
         self._stopping = True
         self._disconnecting = True
@@ -360,20 +294,10 @@ class ComfoConnect(object):
         return self._bridge.is_connected()
 
     def register_sensor(self, sensor_id: int, sensor_type: int = None):
-        """Register a sensor on the bridge and keep it in memory that we are registered to this sensor.
+        """Meldet einen Sensor bei der Anlage an.
 
-        Single attempt only - no retry, no cancel-and-retry dance. That used to exist to
-        recover from a single dropped CnRpdoConfirm, but retrying introduced its own risk
-        (a second CnRpdoRequestType for a pdid whose first request might still be in
-        flight, not actually lost, observed to sometimes trigger a bridge-side connection
-        reset) and, in practice, often didn't help anyway - a sensor that doesn't answer
-        within the standard reply timeout is either genuinely unsupported by this hardware
-        or will work fine on the NEXT registration pass (after a reconnect).
-
-        Uses the same plain reply timeout as every other command - on real hardware the
-        bridge confirms each subscription within a few milliseconds (a full 50-sensor
-        sweep measured at well under a second), so anything approaching seconds here
-        already means something is genuinely wrong, not just slow.
+        Ein Versuch ohne Wiederholung. Liefert None, wenn die Anlage den Sensor
+        nicht kennt; nur OSError wird weitergereicht, weil dann die Verbindung fehlt.
         """
 
         if not sensor_type:
@@ -436,15 +360,7 @@ class ComfoConnect(object):
         self.cmd_rpdo_request(sensor_id, sensor_type, timeout=0)
 
     def _command(self, command, params=None, use_queue=True, context=None):
-        """Sends a command and wait for a response if the request is known to return a result.
-
-        Every command waits the same standard reply timeout (see _get_reply) - there is
-        deliberately no per-call override anymore.
-
-        context: short human-readable label (e.g. "pdid=146") included in _get_reply()'s
-        timeout log line, so a timeout message identifies what it was actually waiting for
-        instead of just the confirm type.
-        """
+        """Sendet einen Befehl und wartet auf die zugehoerige Antwort."""
 
         # Reference-number generation and the actual socket write both have to be
         # atomic across threads - see the _command_lock comment in __init__ for why
@@ -469,12 +385,7 @@ class ComfoConnect(object):
             # Increase message reference
             self._reference += 1
 
-            # Be careful when sending message, we need to catch a broken connection here.
-            # Previously this swallowed the error and returned False, which no caller
-            # checked - execution just carried on to wait a full timeout for a reply to
-            # a message that was never sent. Re-raise instead, so callers that expect
-            # OSError (register_sensor, _connection_thread_loop) find out immediately
-            # and can trigger a proper reconnect instead of a doomed retry.
+            # Beim Senden kann die Verbindung wegbrechen - der Fehler wird oben behandelt.
             try:
                 self._bridge.write_message(message)
 
@@ -500,22 +411,8 @@ class ComfoConnect(object):
             return None
 
         except OSError:
-            # Same %-formatting trap as described in _connection_thread_loop: these
-            # must be concatenated into one string, not passed as extra positional
-            # args, otherwise logging itself raises TypeError and spams the log.
-            #
-            # During an intentional shutdown (self._disconnecting, see
-            # mark_disconnecting()) this is expected, not an error: cmd_close_session()
-            # sends CloseSessionRequest and the bridge closes the socket right after,
-            # which surfaces here as exactly this OSError. The caller (the SIGTERM
-            # handler in cfc.py) already logs a calm, accurate INFO line for that case -
-            # log this one quietly too instead of a scary, redundant ERROR right above it.
-            # .__name__, not str(): str() of a protobuf class gives
-            # "<class 'zehnder_pb2.CloseSessionConfirm'>" - and LoxBerry's web log viewer
-            # renders the log as HTML, so it swallows that whole thing as an unknown tag
-            # and the type silently disappears from the displayed line (it IS in the raw
-            # file, just invisible where you'd normally read it). The bare name shows up
-            # fine and is the only interesting part anyway.
+            # Meldungstext ohne %-Formatierung zusammensetzen: Der Inhalt kann Prozent-
+            # zeichen enthalten, die logging sonst als Platzhalter deutet.
             if self._disconnecting:
                 _LOGGER.info("_command._get_reply für confirm type " + confirm_type.__name__ + " abgebrochen (beabsichtigtes Herunterfahren): " + sys.exc_info()[0].__name__)
             else:
@@ -523,30 +420,10 @@ class ComfoConnect(object):
             raise
 
     def _session_verloren(self, grund, use_queue):
-        """Behandelt eine Antwort, die bedeutet: die Anlage kennt unsere Sitzung nicht mehr.
+        """Behandelt eine von der Anlage verworfene Sitzung.
 
-        NOT_ALLOWED heisst im Protokoll "nicht authentifiziert". Beobachtet in der
-        Praxis: Die Anlage verwirft eine laufende Sitzung, laesst die TCP-Verbindung
-        aber offen. Danach beantwortet sie jede Anfrage mit NOT_ALLOWED und schickt
-        keine Sensordaten mehr.
-
-        Von aussen war das praktisch unsichtbar:
-          - die Leseschleife dreht weiter und frischt last_alive_ping auf
-          - cmd_keepalive() erwartet gar keine Antwort und "gelingt" deshalb immer
-          - Sensordaten bleiben aus, was nur die (standardmaessig ausgeschaltete)
-            Sensorwert-Ueberwachung bemerkt haette
-        In einem echten Fall: zwei Stunden lang kein einziger Messwert, waehrend das
-        Plugin sich fuer kerngesund hielt. Vorher stand hier gar keine Behandlung -
-        der Zustand blieb bis zum naechsten Neustart bestehen.
-
-        Die Antwort darauf ist gezielt und NICHT "alles wegwerfen": Der Message-Thread
-        wird beendet, damit anschliessend eine neue Sitzung angemeldet werden kann
-        (siehe _connection_thread_loop). Die TCP-Verbindung bleibt dabei bestehen.
-
-        use_queue unterscheidet die Betriebsphase: Waehrend des Verbindungsaufbaus
-        (use_queue=False) ist NOT_ALLOWED voellig normal - es bedeutet dort "App noch
-        nicht registriert" und wird von _connect() gezielt abgefangen, um die
-        Registrierung nachzuholen. Nur im laufenden Betrieb ist es ein Alarmzeichen.
+        Zaehlt die Verluste in einem gleitenden Zeitfenster. Haeufen sie sich, deutet
+        das auf einen zweiten Client hin - die Anlage erlaubt nur eine Sitzung.
         """
         if not use_queue:
             return
@@ -582,43 +459,16 @@ class ComfoConnect(object):
         self._stopping = True
 
     def _get_reply(self, confirm_type=None, timeout=5, use_queue=True, expected_reference=None, context=None):
-        """Pops a message of the queue, optionally looking for a specific type.
+        """Wartet auf die Antwort zu einer Anfrage.
 
-        context: short human-readable label (e.g. "pdid=146") for the timeout log line -
-        see _command()'s docstring.
-
-        expected_reference: the message.cmd.reference value of OUR OWN request. When the
-        bridge is backed up (busy flushing notifications for already-registered sensors,
-        see the timeout handling above), confirms can arrive many seconds late and out of
-        order relative to when we gave up waiting and retried. Without this check, a stale
-        confirm belonging to an earlier, already-abandoned attempt - carrying the SAME
-        message class (e.g. CnRpdoConfirmType) but a DIFFERENT reference number - used to
-        satisfy this wait anyway, since only the class was checked. That silently handed
-        register_sensor() a "success" for the wrong request: no timeout, no warning, but
-        the confirm for the actual current attempt (and the real sensor data) could still
-        be minutes away or never verified at all. Observed directly in a log: retry #2 for
-        a sensor's registration was quietly satisfied by a ~9s-late confirm meant for a
-        completely different, already-abandoned earlier attempt.
+        Ordnet ueber die Referenznummer zu. Antworten auf bereits aufgegebene
+        Anfragen werden verworfen, statt spaeteren Wartenden untergeschoben zu werden.
         """
 
         start = time.time()
 
-        # Messages pulled off self._queue that turn out not to be ours (wrong
-        # reference, or a genuine type mismatch) - buffered locally and only put
-        # back onto the shared queue once this call is about to return, instead of
-        # immediately re-queueing each one on the spot. Immediately re-queueing
-        # caused a tight infinite loop in practice: a single orphaned confirm (e.g.
-        # a very late reply for an attempt we'd already given up on and retried
-        # past) gets popped, found not to match, pushed straight back onto the same
-        # queue - which this same loop then immediately pops again, since nothing
-        # else is there to get in between. That spins as fast as the CPU allows,
-        # burning 100% of a core and flooding the log (observed: tens of thousands
-        # of "Ignoring confirm..." lines within a few milliseconds) until the
-        # timeout eventually fires. Buffering locally means every pass through the
-        # loop makes real progress - either finding our own message further back in
-        # the queue, or genuinely blocking in queue.get() for something new to
-        # arrive - and nothing is lost: anyone else who still needs one of these
-        # gets it back once we're done here (success, timeout, or error).
+        # Nachrichten, die nicht zu dieser Anfrage gehoeren, wandern zurueck in die
+        # Warteschlange - ein anderer Aufrufer wartet moeglicherweise darauf.
         deferred = []
 
         try:
@@ -632,9 +482,7 @@ class ComfoConnect(object):
                         if message:
                             self._queue.task_done()
 
-                            # The message thread died because the connection is gone - don't
-                            # wait out the rest of our own timeout for a reply that can never
-                            # arrive, fail immediately instead.
+                            # Der Nachrichten-Thread meldet den Verbindungsverlust - nicht auf das Zeitlimit warten.
                             if message is _CONNECTION_LOST:
                                 raise BrokenPipeError('Connection lost while waiting for a reply.')
                     except queue.Empty:
@@ -646,13 +494,8 @@ class ComfoConnect(object):
                     message = self._bridge.read_message(timeout=timeout)
 
                 if message:
-                    # Whether this particular message is actually the one we're waiting for -
-                    # right type, and (if we know our own reference) the matching reference too.
-                    # Status codes below are only meaningful for OUR OWN request's reply: a
-                    # BAD_REQUEST/NOT_EXIST/etc. on some other, unrelated stale/out-of-order
-                    # message must not be misattributed to the request we're currently making
-                    # (that used to happen here, since the status check ran unconditionally on
-                    # every message before the type/reference was even looked at).
+                    # Passt die Nachricht zu dieser Anfrage? Typ allein genuegt nicht, die
+                    # Referenznummer muss stimmen.
                     is_ours = confirm_type is not None and message.msg.__class__ == confirm_type and (
                         expected_reference is None or message.cmd.reference == expected_reference
                     )
@@ -684,24 +527,14 @@ class ComfoConnect(object):
                         # We just need a message
                         return message
                     elif is_ours:
-                        # We need the message with the correct type AND, if we know which
-                        # reference we're actually waiting for, the matching reference - see
-                        # the expected_reference docstring above for why the reference check
-                        # matters (right type alone isn't enough once replies can arrive
-                        # several seconds late and out of order).
+                        # Richtiger Typ und passende Referenz - dann ist es unsere Antwort.
                         return message
                     elif message.msg.__class__ == confirm_type:
                         # Right type, but for a different (older or newer) request than the
                         # one we're currently waiting on - not ours.
                         if message.cmd.reference in self._abandoned_references:
-                            # We ourselves already gave up on this exact reference (a plain
-                            # timeout, see below) - nobody is ever going to claim it, so
-                            # discard it here and now instead of deferring it. Deferring
-                            # would just hand it back onto self._queue, where the NEXT
-                            # unrelated wait pops it, rejects it again, and defers it again -
-                            # forever, for the rest of this connection's lifetime (harmless,
-                            # but a permanently recurring log line for something we already
-                            # know is dead).
+                            # Auf diese Referenz warten wir nicht mehr (Zeitlimit). Verwerfen, damit sie
+                            # nicht dauerhaft in der Warteschlange kreist.
                             self._zaehle('verworfene_antworten')
                             _LOGGER.debug(
                                 "Discarding orphaned confirm for a reference we already gave up on: "
@@ -717,18 +550,8 @@ class ComfoConnect(object):
                                 + str(expected_reference) + ": got reference " + str(message.cmd.reference)
                             )
                     elif message.cmd.type == GatewayOperation.CnRpdoNotificationType:
-                        # Not a mismatched reply - this is a completely normal, unsolicited
-                        # sensor-value push that can arrive at any time, including while we're
-                        # waiting for an unrelated confirm (e.g. during the initial
-                        # StartSessionConfirm handshake right after a reconnect/takeover, before
-                        # the bridge has finished flushing notifications tied to the previous
-                        # session). _message_thread_loop routes these the same way once it takes
-                        # over - do it here too instead of logging a scary "incorrect type"
-                        # warning and stranding the message in self._queue (which nobody
-                        # drains while use_queue=False, e.g. during cmd_start_session), which
-                        # used to eat into this call's own timeout budget for no reason and
-                        # could make the initial handshake fail/crash if enough of these arrived
-                        # in a row.
+                        # Kein verirrter Rueckschein, sondern eine unaufgeforderte Sensormeldung.
+                        # Wird direkt verarbeitet statt zurueckgelegt.
                         self._handle_rpdo_notification(message)
                     elif message.cmd.type in (
                         GatewayOperation.GatewayNotificationType,
@@ -740,11 +563,7 @@ class ComfoConnect(object):
                         # while we're waiting for our own confirm. Log at debug, not warning.
                         _LOGGER.debug("Ignoring unsolicited notification while waiting for a reply: " + str(message.cmd.type))
                     else:
-                        # A genuine mismatch: some other command's reply, unexpectedly out of
-                        # order. This is the case the original code was written for - defer it
-                        # (see comment above on `deferred`) so whoever is actually waiting for
-                        # it can still find it once we're done here, without this loop
-                        # immediately re-popping the same message.
+                        # Antwort eines anderen Befehls, ausser der Reihe eingetroffen.
                         deferred.append(message)
                         _LOGGER.warning("We got a message with an incorrect type." + str(message.msg.__class__))
 
@@ -778,10 +597,7 @@ class ComfoConnect(object):
                     self._zaehle('antwort_timeouts', 'letzter_timeout')
                     _LOGGER.error("Timeout waiting for response. " + detail)
 
-                    # Identity check against the imported class, not a string comparison
-                    # against its repr - the old "<class 'zehnder_pb2.CnRmiResponse'>"
-                    # string would silently stop matching if the module/class were ever
-                    # renamed or the protobuf runtime changed how it formats a class.
+                    # Vergleich mit der Klasse selbst, nicht mit ihrem Namen als Zeichenkette.
                     if confirm_type is CnRmiResponse:
                         # RMI-Aufrufe melden das Ausbleiben ueber den Rueckgabewert
                         # statt ueber eine Ausnahme.
@@ -789,9 +605,8 @@ class ComfoConnect(object):
 
                     raise ValueError('Timeout waiting for response.')
         finally:
-            # Give back anything we picked up along the way that wasn't ours, so
-            # whoever it actually belongs to (or the next call, or _message_thread_loop's
-            # own routing) can still find it - see the `deferred` comment above.
+            # Fremde Nachrichten zurueck in die Warteschlange - ein anderer Aufrufer
+            # wartet moeglicherweise darauf.
             for m in deferred:
                 self._queue.put(m)
 
@@ -806,10 +621,8 @@ class ComfoConnect(object):
 
             # Start connection
             if not self.is_connected():
-                # Not ready for MQTT publishing again until the sensors below have all
-                # been (re-)attempted on the new connection - see the attribute comment
-                # in __init__ for why. Also marks this as a genuine reconnect, not the
-                # initial connect - see the _is_reconnect comment in __init__.
+                # Anmeldung der Sensoren steht noch aus; kennzeichnet ausserdem einen echten
+                # Wiederaufbau.
                 self.sensors_ready = False
                 self._is_reconnect = True
 
@@ -877,25 +690,11 @@ class ComfoConnect(object):
                 # Vorfall und darf erneut gezaehlt und gemeldet werden.
                 self._abbruch_gemeldet = False
 
-                # Reset the queue here, synchronously, BEFORE starting the message
-                # thread - not as the first line inside _message_thread_loop() itself.
-                # thread.start() returns as soon as the OS has scheduled the new
-                # thread, not once it has actually run any code, so this loop carries
-                # straight on to register_sensor() below while the new thread's very
-                # first instructions are still pending. If _message_thread_loop() were
-                # the one resetting self._queue, a _get_reply() call from the
-                # registration loop below could grab a reference to the OLD Queue
-                # object in that window, then the reset swaps self._queue to a new one
-                # out from under it - the waiting call is now stuck listening on an
-                # orphaned queue that will never receive anything, and just times out
-                # uselessly even though a real reply arrived. Doing the reset here
-                # instead, synchronously in this same thread right before start(),
-                # closes that window entirely.
+                # Warteschlange hier leeren, nicht im Nachrichten-Thread: Sonst koennte ein
+                # Wartender noch die alte erwischen und ins Leere lauschen.
                 self._queue = queue.Queue()
 
-                # A fresh connection means a fresh set of reference numbers too (see
-                # __init__) - any previously abandoned reference can never legitimately
-                # reappear on this new connection, so drop the bookkeeping along with it.
+                # Neue Verbindung, neue Referenznummern.
                 self._abandoned_references = set()
                 self._session_invalid = False
 
@@ -914,36 +713,14 @@ class ComfoConnect(object):
                     registration_ok = True
                     # need to handle exceptions during sensor re-registration to have a robust library
                     try:
-                        # list(...) takes a snapshot of the dict before iterating: cfc.py's
-                        # main thread can concurrently add entries to self.sensors (e.g. the
-                        # startup registration loop pre-remembering not-yet-attempted sensors
-                        # after losing the connection), and iterating a dict directly while
-                        # another thread changes its size raises "RuntimeError: dictionary
-                        # changed size during iteration" - which used to kill this thread the
-                        # same way the bugs fixed earlier did.
-                        # Ein Sensor, den die Anlage nicht (mehr) kennt, wird auch hier
-                        # uebersprungen statt den ganzen Durchlauf abzubrechen.
-                        #
-                        # Frueher stand hier ein Abbruch mit der Begruendung, jeder
-                        # Eintrag in self.sensors habe sich ja schon einmal erfolgreich
-                        # registriert. Das stimmt aber nicht: cfc.py traegt bei einem
-                        # Verbindungsverlust auch die noch gar nicht versuchten Sensoren
-                        # hier ein, damit sie nach dem Reconnect nachgeholt werden.
-                        # Darunter koennen nicht unterstuetzte sein - der Abbruch haette
-                        # dann bei jedem Reconnect erneut zugeschlagen und eine
-                        # Endlosschleife aus abgebrochenen Verbindungsversuchen erzeugt.
+                        # Kopie der Liste vor dem Durchlauf: cfc.py kann waehrenddessen Sensoren
+                        # ergaenzen, was sonst den Durchlauf abbrechen wuerde.
                         for sensor_id, sensor_type in list(self.sensors.items()):
                             self.register_sensor(sensor_id, sensor_type)
 
                     except OSError:
-                        # NOTE: string concatenation, NOT a second argument. logging
-                        # treats extra positional args as %-format arguments for the
-                        # message - passing one without a matching %s in the string
-                        # raises "TypeError: not all arguments converted during string
-                        # formatting" inside logging itself, which then dumps a full
-                        # "--- Logging error ---" block plus two tracebacks into the
-                        # log on every single reconnect. Harmless for program flow,
-                        # but it buried the actual message in ~35 lines of noise.
+                        # Text zusammensetzen statt als zweites Argument uebergeben - logging deutete
+                        # Prozentzeichen darin sonst als Platzhalter.
                         _LOGGER.error("Unexpected error in _connection_thread_loop while registering sensors: " + sys.exc_info()[0].__name__)
                         registration_ok = False
 
@@ -955,19 +732,9 @@ class ComfoConnect(object):
                         _LOGGER.info(str(len(self.sensors)) + ' sensor(s) registered, ready event set.')
                         if self._is_reconnect:
                             self.sensors_ready = True
-                        # else: this was the very first connect - self.sensors was (and
-                        # still is, most likely) empty because cfc.py's own startup sweep
-                        # runs concurrently in the main thread and hasn't populated it
-                        # yet. Leave sensors_ready alone; cfc.py sets it itself once ITS
-                        # sweep actually finishes (see main()).
+                        # Erster Verbindungsaufbau - cfc.py meldet die Sensoren selbst an.
                 else:
-                    # Nothing to (re-)register (e.g. reconnecting before cfc.py's startup
-                    # sweep ever ran, or a genuine reconnect with no sensors left to
-                    # restore) - nothing is blocking readiness, but only say so for an
-                    # actual reconnect. On the very first connect this branch is
-                    # basically always taken too (self.sensors starts empty - see
-                    # above), and must NOT flip sensors_ready True early - that's
-                    # cfc.py's call once its own startup sweep is done.
+                    # Nichts anzumelden, etwa beim Wiederaufbau vor dem ersten Durchlauf in cfc.py.
                     if self._is_reconnect:
                         self.sensors_ready = True
 
@@ -1038,21 +805,13 @@ class ComfoConnect(object):
     def _message_thread_loop(self):
         """Listen for incoming messages and queue them or send them to a callback method."""
 
-        # NOTE: self._queue is deliberately NOT reset here anymore - it's reset
-        # synchronously in _connection_thread_loop() right before this thread is
-        # started, to avoid a race where a _get_reply() call already running (e.g.
-        # from the sensor registration loop right after connect()) could grab a
-        # reference to the queue object that's about to be replaced out from under
-        # it. See the comment there for details.
+        # Die Warteschlange wird bewusst im Verbindungs-Thread geleert, nicht hier.
 
         next_keepalive = 0
 
         while not self._stopping:
 
-            # Every loop iteration proves this thread is alive and not hung/blocked
-            # somewhere - the cheapest, most fine-grained "still alive" signal we have
-            # (the loop cycles roughly once per second thanks to bridge.read_message()'s
-            # internal 1s select timeout). Persisting this to disk is the caller's job.
+            # Jeder Durchlauf belegt, dass dieser Thread noch laeuft.
             self.last_alive_ping = time.time()
 
             # Sends a keepalive every KEEPALIVE seconds.
@@ -1072,10 +831,8 @@ class ComfoConnect(object):
                 message = self._bridge.read_message()
 
             except BrokenPipeError as exc:
-                # Close this thread. The connection_thread will restart us - unless
-                # self._disconnecting is set (see mark_disconnecting()/disconnect()),
-                # in which case this socket dying is exactly what we asked for by
-                # sending CloseSessionRequest, not a real failure to report/recover from.
+                # Thread beenden; der Verbindungs-Thread startet ihn neu, sofern kein
+                # beabsichtigtes Trennen vorliegt.
                 if self._disconnecting:
                     _LOGGER.info("Verbindung getrennt (beabsichtigtes Herunterfahren)." + str(exc))
                 else:
@@ -1134,8 +891,7 @@ class ComfoConnect(object):
                         _LOGGER.info('Bridge hat die Session geschlossen (beabsichtigtes Herunterfahren).')
                     else:
                         _LOGGER.info('The Bridge has asked us to close the connection. We will try to reconnect later.')
-                    # Close this thread. The connection_thread will restart us (unless
-                    # self._disconnecting is set, see mark_disconnecting()).
+                    # Thread beenden; der Verbindungs-Thread startet ihn neu.
                     return
 
                 else:
@@ -1145,15 +901,13 @@ class ComfoConnect(object):
         return
 
     def _handle_rpdo_notification(self, message):
-        """Update internal sensor state and invoke callback."""
+        """Wertet einen eingehenden Sensorwert aus und reicht ihn an den Rueckruf weiter."""
 
         # Only process CnRpdoNotificationType
         if message.cmd.type != GatewayOperation.CnRpdoNotificationType:
             return False
 
-        # Proof that data is actually flowing from the ventilation unit - tracked per
-        # notification regardless of which sensor, since any single sensor may
-        # legitimately stay silent for a long time (e.g. filter days remaining).
+        # Beleg, dass Daten fliessen - unabhaengig davon, welcher Sensor gesendet hat.
         self.last_sensor_data = time.time()
 
         # Extract data
@@ -1188,19 +942,7 @@ class ComfoConnect(object):
                               % (message.msg.pdid, type(e).__name__, e))
 
     def _handle_alarm_notification(self, message):
-        """Wertet eine CnAlarmNotification aus und meldet die Fehler im Klartext.
-
-        Die Nachricht enthaelt ein 32-Byte-Bitfeld "errors": jedes gesetzte Bit ist
-        ein anstehender Fehler, die Bitnummer der Schluessel in den Tabellen aus
-        const.py. Innerhalb eines Bytes wird vom niederwertigsten Bit aufwaerts
-        gezaehlt, die Bitnummer ist also Byte-Index * 8 + Bit-Index.
-
-        Nachgerechnet an einem echten Alarm dieser Anlage: Byte 6 = 0x20 ergibt
-        Bitnummer 53, und genau 53 steht auch im Feld errorId derselben Nachricht.
-
-        Frueher stand hier nur "Unhandled CnAlarmNotificationType" - die Anlage hat
-        ihre Stoerung also gemeldet, im Log war davon aber nichts zu sehen.
-        """
+        """Wertet eine Stoerungsmeldung aus und uebersetzt die Fehlerbits in Klartext."""
 
         errors = {}
         try:
@@ -1238,15 +980,7 @@ class ComfoConnect(object):
             self.callback_alarm(node_id, errors)
 
     def cmd_clear_errors(self):
-        """Quittiert anstehende Fehlermeldungen der Anlage.
-
-        Entspricht dem Zuruecksetzen ueber das Bedienteil bzw. die App. Unit 0x03
-        ist die Fehler-Einheit, 0x82 der zugehoerige Quittierbefehl.
-        Quelle: aiocomfoconnect, clear_errors().
-
-        Fehler, deren Ursache noch besteht, meldet die Anlage danach sofort wieder -
-        Quittieren ersetzt also keine Behebung.
-        """
+        """Quittiert die an der Anlage anstehenden Stoerungen."""
         return self.cmd_rmi_request(b'\x82\x03\x01')
 
         return True
@@ -1268,22 +1002,7 @@ class ComfoConnect(object):
         return reply  # TODO: parse output
 
     def cmd_close_session(self, use_queue: bool = True):
-        """Tells the bridge we're intentionally ending this session.
-
-        Without ever calling this, the bridge has no way to know a disconnect is
-        intentional vs. the client just vanishing (process killed, network drop) -
-        it was observed to keep the old session around for several seconds ("resumed:
-        true" on the next StartSessionConfirm) before handing over to a reconnecting
-        client, flushing a backlog of leftover messages tied to the old session in the
-        process. See cfc.py's SIGTERM handler, which calls this during a
-        "Speichern"-triggered restart so the bridge can drop the session cleanly before
-        the new process connects.
-
-        Uses the standard reply timeout like everything else. That timeout is almost
-        never reached: the bridge responds by closing the socket instead of sending a
-        CloseSessionConfirm, which wakes the waiting call immediately (see
-        _CONNECTION_LOST) rather than letting it run out the clock.
-        """
+        """Meldet die Sitzung bei der Anlage ab."""
 
         reply = self._command(
             CloseSessionRequest,
@@ -1358,17 +1077,7 @@ class ComfoConnect(object):
         return reply.msg.currentTime
 
     def cmd_rmi_request(self, message, node_id: int = 1, use_queue: bool = True):
-        """Sends a RMI request and returns the bridge's reply.
-
-        Gibt die Antwort zurueck statt eines nichtssagenden True: RMI ist nicht nur
-        zum Schalten da, es gibt auch Lesebefehle (0x01 = Eigenschaft lesen, 0x83 =
-        Timer-Eintrag lesen). Deren Nutzdaten stehen in reply.msg.message - mit dem
-        alten "return True" waren sie schlicht nicht erreichbar, die Antwort wurde
-        eingelesen und weggeworfen.
-
-        Rueckgabe ist None/False, wenn keine verwertbare Antwort kam (siehe
-        _get_reply: bei einem Timeout auf CnRmiResponse wird False geliefert).
-        """
+        """Sendet eine RMI-Anfrage und liefert die Antwort zurueck."""
 
         reply = self._command(
             CnRmiRequest,
@@ -1402,7 +1111,7 @@ class ComfoConnect(object):
         return reply
 
     def cmd_keepalive(self, use_queue: bool = True):
-        """Sends a keepalive."""
+        """Sendet ein Keepalive. Die Anlage beantwortet es nicht."""
 
         self._command(
             KeepAlive,

--- a/templates/multi/main.html
+++ b/templates/multi/main.html
@@ -1,12 +1,7 @@
 <style>
-	/* Eigenes, lokales CSS fuer die Label+Feld-Zeilen - angelehnt an das
-	   lb-form-row/lb-form-label/lb-form-field-Muster aus dem offiziellen
-	   LoxBerry-4-Sample-Plugin (github.com/mschlenstedt/LoxBerry-Plugin-
-	   SamplePlugin-V4), aber mit eigenen Klassennamen und ohne Abhaengigkeit
-	   von der Core-components.css. Die lb-* Klassen sind laut Core-CSS-Header
-	   ausdruecklich noch nicht fuer Plugins freigegeben ("Plugins keep jQuery
-	   Mobile") und womoeglich auf LB3 gar nicht geladen - mit einer eigenen
-	   Kopie funktioniert es auf beiden Versionen gleich. */
+	/* Label-und-Feld-Zeilen. Eigene Klassen statt der lb-*-Klassen des Cores:
+	   Die sind laut Core-CSS noch nicht fuer Plugins freigegeben und auf LB3
+	   moeglicherweise gar nicht geladen. */
 	.cc-row {
 		display: flex;
 		align-items: center;
@@ -22,14 +17,8 @@
 		flex: 0 0 190px !important;
 		width: 190px !important;
 		box-sizing: border-box;
-		/* Rechnerisch zentriert die Flexbox Label und Feld bereits exakt (siehe
-		   DevTools-Messung), der minimale Versatz kommt von der Baseline-Position
-		   des Textes innerhalb von <input> vs. <label> - per Augenmass korrigiert.
-		   !important noetig: jQuery Mobile setzt ".ui-mobile label, .ui-controlgroup-label"
-		   mit "margin: 0 0 .4em" (Klasse+Tag = hoehere Spezifitaet als unsere reine
-		   Klassenregel). Komplettes Shorthand ueberschreiben (nicht nur margin-top),
-		   sonst bleibt jQMs margin-bottom:.4em stehen und macht das Label insgesamt
-		   hoeher als das Eingabefeld - dann kippt die Zentrierung erst recht. */
+		/* !important noetig: jQuery Mobile setzt label-Abstaende per Tag-Selektor und
+		   schlaegt damit eine reine Klassenregel. */
 		margin: 6px 0 0 0 !important;
 	}
 	.cc-field {
@@ -38,33 +27,20 @@
 		gap: 10px;
 	}
 
-	/* Einheitliche Schriftart fuer den gesamten Plugin-Bereich (Intro-Box, Status,
-	   Formular, Hinweistexte), unabhaengig davon, was die umgebende LoxBerry-Version
-	   auf body/Vorfahren-Ebene vorgibt - vermeidet einen Stilbruch zwischen z.B. der
-	   kursiven Intro-Box und dem Rest, wenn LB3 und LB4 hier unterschiedliche
-	   Standardschriften mitbringen. Gaengiger System-Sans-Serif-Stack statt einer
-	   externen Schriftart, damit nichts nachgeladen werden muss. */
+	/* Einheitliche Schrift fuer den Plugin-Bereich, unabhaengig davon, was die
+	   umgebende LoxBerry-Version vorgibt. */
 	.cc-plugin {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-		/* Der LoxBerry-Inhaltsbereich ist voll bildschirmbreit. Ohne Begrenzung
-		   ziehen sich die gerahmten Bloecke auf einem Desktop ueber die gesamte
-		   Breite, wodurch der Hilfetext meterweit von den Feldern entfernt steht,
-		   auf die er sich bezieht. Zentriert und begrenzt bleiben Rahmen und
-		   Zuordnung lesbar; auf schmalen Geraeten greift die Begrenzung nicht. */
+		/* Breite begrenzen: Sonst steht der Hilfetext auf einem Desktop meterweit von
+		   den Feldern entfernt, auf die er sich bezieht. */
 		max-width: 1150px;
-		/* Negativer oberer Rand: der umgebende Inhaltsbereich (jQuery Mobile
-		   ".ui-content") bringt einen eigenen Innenabstand mit, der oberhalb der
-		   Beschreibung als breiter, ungenutzter Streifen sichtbar war. Von hier aus
-		   laesst er sich nicht abschalten, ohne fremde Klassen zu ueberschreiben -
-		   ein moderater negativer Rand holt den Block hoch, ohne in den Kopfbereich
-		   zu ragen, falls eine andere LoxBerry-Version dort weniger Abstand hat. */
+		/* Negativer oberer Rand holt den Block hoch - der umgebende Inhaltsbereich
+		   bringt einen eigenen Innenabstand mit, der sich hier nicht abschalten laesst. */
 		margin: -18px auto 0 auto;
 	}
 
-	/* Ersetzt die alte, kursive Intro-Box (Klartext-<i>-Tag + Inline-Styles) durch
-	   eine ruhigere, mit dem Rest der Seite einheitliche Optik. Bewusst schmal
-	   gehalten (Padding/Margin), damit Formular und Buttons ohne Scrollen auf den
-	   Schirm passen - der Text ist eine einmalige Erklaerung, kein Arbeitsbereich. */
+	/* Beschreibungskasten oben. Bewusst schmal, damit die Schaltflaechen ohne
+	   Scrollen sichtbar bleiben. */
 	.cc-intro {
 		background-color: #fdf8e3;
 		border-radius: 8px;
@@ -81,25 +57,17 @@
 		color: #4a4a4a;
 	}
 
-	/* Ersetzt die <font size="-1">-Hinweistexte neben den Eingabefeldern - gleiche
-	   Familie wie der Rest (.cc-plugin), nur etwas kleiner/gedaempft. */
+	/* Hinweistexte neben den Eingabefeldern. */
 	.cc-hint-text {
 		font-size: 0.85em;
 		color: #666;
 	}
 
-	/* Gerahmte Themenbloecke. Ersetzen die frueheren Tabellenzeilen samt separater
-	   Label-Spalte: die Gruppenueberschrift steht jetzt im Block selbst, wodurch die
-	   20%-Spalte links komplett entfaellt und der Block deutlich flacher wird.
-
-	   Bewusst <div> und NICHT <fieldset>/<legend>, obwohl letzteres die semantisch
-	   schoenere Gruppierung waere: jQuery Mobile und das LoxBerry-Core-CSS setzen
-	   fieldset per Tag-Selektor auf "border:0; padding:0; margin:0" zurueck. Das
-	   schlaegt eine reine Klassenregel und haette den Rahmen komplett verschluckt -
-	   in der Praxis genau so passiert (Gruppen ohne Rahmen, Zeilen ineinander
-	   laufend, weil auch das Padding weg war). Mit div gibt es diesen Reset nicht.
-	   Die !important bleiben als Absicherung gegen weitere Tag-Selektoren aus dem
-	   umgebenden Theme - dieselbe Ueberlegung wie bei .cc-label oben. */
+	/* Gerahmte Themenbloecke.
+	   
+	   Bewusst div und nicht fieldset: jQuery Mobile und das Core-CSS setzen
+	   fieldset per Tag-Selektor zurueck, der Rahmen waere sonst unsichtbar.
+	   Die !important sichern gegen weitere Tag-Selektoren des Themes ab. */
 	.cc-group {
 		display: block;
 		border: 1px solid #d5d5d5 !important;
@@ -114,9 +82,8 @@
 		margin: 0 0 8px 0 !important;
 		padding: 0;
 	}
-	/* Felder links, Hilfetext rechts daneben - vorher lag der Hilfetext in einer
-	   eigenen Tabellenspalte. flex-wrap sorgt dafuer, dass er auf schmalen Schirmen
-	   (Handy/Tablet) unter die Felder rutscht statt sie zu quetschen. */
+	/* Felder links, Hilfetext rechts. flex-wrap laesst ihn auf schmalen Schirmen
+	   darunter rutschen. */
 	.cc-group-body {
 		display: flex;
 		flex-wrap: wrap;
@@ -133,19 +100,15 @@
 		max-width: 420px;
 	}
 
-	/* Zeilen, die von einer uebergeordneten Checkbox abhaengen (siehe
-	   update_sensorwatch_fields unten). Das disabled-Attribut alleine graut zwar das
-	   Eingabefeld aus, nicht aber dessen Label - ohne diese Regel sieht die Zeile
-	   halb aktiv aus. Rein optisch: die eigentliche Sperre macht das disabled-Attribut,
-	   nicht diese Klasse. */
+	/* Von einer uebergeordneten Checkbox abhaengige Zeilen. Rein optisch - die
+	   Sperre selbst macht das disabled-Attribut. */
 	.cc-dependent.cc-disabled label,
 	.cc-dependent.cc-disabled input {
 		opacity: 0.45;
 	}
 
-	/* Diagnosetabelle. Bewusst zurueckhaltend gestaltet: Das sind Hinweise fuer
-	   den Fehlerfall, keine Betriebsanzeige - sie sollen nicht mit der
-	   Statuszeile oben um Aufmerksamkeit konkurrieren. */
+	/* Diagnosetabelle. Bewusst zurueckhaltend - Hinweise fuer den Fehlerfall,
+	   keine Betriebsanzeige. */
 	.cc-diag-runtime {
 		font-size: 0.9em;
 		color: #555;
@@ -262,10 +225,8 @@
 		padding: 1px 10px 1px 0;
 		border-bottom: 1px solid #f2f2f2;
 		vertical-align: middle;
-		/* Siehe die gleichlautende Regel bei table.cc-cmds: gemeinsame Zeilenhoehe,
-		   damit Schreibmaschinen- und Proportionalschrift auf derselben Grundlinie
-		   sitzen. */
-		line-height: 1.7;
+		/* Fester Wert, siehe die gleichlautende Regel bei table.cc-cmds. */
+		line-height: 20px;
 	}
 	table.cc-sensors td * { line-height: inherit; }
 	/* Abgewaehlte Zeilen blass, aber lesbar - sie sollen als "aus" erkennbar
@@ -278,23 +239,16 @@
 	}
 	.cc-sensor-name-fix { font-family: monospace; width: 230px; }
 	.cc-sensor-push-fix { color: #888; width: 62px; }
-	/* Feste Breite fuer die Hakenspalte: Die Kopfzeile steht in einer eigenen
-	   Tabelle (wegen der Gruppenueberschriften dazwischen), ohne feste Breite
-	   wuerde sie anders umbrechen als die Datentabellen darunter. Breit genug
-	   fuer die Ueberschrift "Aktiv", der Haken sitzt darunter linksbuendig. */
-	/* Eingerueckt gegenueber dem Haken in der Gruppenkopfzeile. Ohne diese
-	   Einrueckung stehen beide auf derselben senkrechten Linie, und die
-	   Verschachtelung ist nicht zu sehen - genau das war der Grund, warum der
-	   Gruppenhaken vorher missverstanden wurde. Die Ueberschrift "Aktiv" traegt
-	   dieselbe Klasse und wird deshalb mit eingerueckt. */
+	/* Feste Breite, weil die Kopfzeile in einer eigenen Tabelle steht. Die
+	   Einrueckung setzt die Zeilenhaken sichtbar unter den Gruppenhaken; die
+	   Ueberschrift "Aktiv" traegt dieselbe Klasse und rueckt mit. */
 	.cc-sensor-hak {
 		width: 42px;
 		padding-left: 18px !important;
 	}
-	/* Groesse und Abstaende ausdruecklich setzen, zusaetzlich zum data-role="none"
-	   im Markup. Ein Kaestchen ohne feste Masse richtet sich nach der Schriftgroesse
-	   des Themes und kann dadurch hoeher werden als die Tabellenzeile - dann schiebt
-	   es sich ueber die Gruppenueberschrift darueber. */
+	/* Masse ausdruecklich setzen, zusaetzlich zum data-role="none" im Markup:
+	   Sonst richtet sich das Kaestchen nach der Schrift des Themes und wird
+	   hoeher als die Tabellenzeile. */
 	table.cc-sensors input[type="checkbox"],
 	.cc-sgruppe-kopf input[type="checkbox"] {
 		width: 15px;
@@ -319,9 +273,8 @@
 		margin-bottom: 10px;
 		overflow: hidden;
 	}
-	/* Abgesetzte Kopfzeile. Sie ist der Grund fuer den ganzen Rahmen: Ohne sie
-	   stand der Gruppenhaken senkrecht fast genau ueber dem Haken der ersten
-	   Zeile, und beide lasen sich als Paar statt als Ebene und Unterebene. */
+	/* Kopfzeile der Gruppe. Abgesetzt, damit der Gruppenhaken nicht auf einer Linie
+	   mit den Haken der einzelnen Zeilen steht. */
 	.cc-sgruppe-kopf {
 		display: flex;
 		align-items: center;
@@ -374,14 +327,11 @@
 		padding: 1px 10px 1px 0;
 		border-bottom: 1px solid #f2f2f2;
 		vertical-align: top;
-		/* Feste Zeilenhoehe fuer ALLE Zellen, und die Kindelemente erben sie.
-		   Ohne das sitzt jede Zelle auf einer eigenen Grundlinie: Die Spalte
-		   "Empfangen" verschachtelt drei Schriftgroessen (0.86em Tabelle x 0.92em
-		   Zelle x 0.9em fuer die Zeitspanne), daneben stehen Schreibmaschinen- und
-		   Proportionalschrift. Bei "vertical-align: top" richten sich zwar die
-		   Zellenkanten aus, die Textzeilen darin aber nicht - besonders auffaellig
-		   in der Zeile mit der Uhrzeit. */
-		line-height: 1.7;
+		/* Fester Wert, KEIN Faktor: Ein Faktor wird von jedem Kindelement mit der
+		   eigenen Schriftgroesse neu gerechnet, und die Spalte "Empfangen" ist
+		   kleiner gesetzt als die Bedeutung daneben. Die Zeilenkaesten waeren dann
+		   bis zu 4 px unterschiedlich hoch und die Zellen saessen versetzt. */
+		line-height: 20px;
 	}
 	table.cc-cmds td * { line-height: inherit; }
 	/* Die Kopfzeile liegt in einer eigenen Tabelle (siehe getCommandTable), traegt
@@ -393,11 +343,8 @@
 		color: #555;
 		padding: 2px 10px 4px 0;
 		border-bottom: 1px solid #ddd;
-		/* Die Kopfzellen tragen dieselben Spaltenklassen wie die Datenzellen, damit
-		   die Breiten uebereinstimmen - dabei erben sie aber auch deren
-		   Schreibmaschinenschrift. Die gehoert zu den Werten, nicht zur
-		   Ueberschrift: Sonst steht "Topic" in einer anderen Schrift da als
-		   "Bedeutung" daneben, und die Kopfzeile passt nicht mehr zur Sensorliste. */
+		/* Kopfzellen tragen die Spaltenklassen wegen der Breiten - die Schrift daraus
+		   gehoert aber zu den Werten, nicht zur Ueberschrift. */
 		font-family: inherit;
 	}
 	table.cc-cmds th.cc-cmd-last { text-align: right; }
@@ -642,12 +589,9 @@
 	<div class="cc-group">
 		<div class="cc-group-title">Diagnose</div>
 		<div id="diagbox"><TMPL_VAR NAME=DIAGNOSTICS></div>
-		<!-- Gleiche Auszeichnung wie Abbrechen/Speichern unten (jQuery-Mobile-Button,
-		     data-mini), damit die Seite einheitlich aussieht.
-
-		     Bewusst ein <a> und KEIN <button>: Ein button innerhalb des Formulars
-		     wuerde beim Klick absenden - und damit ausgerechnet einen Neustart des
-		     Plugins ausloesen, waehrend das Zuruecksetzen laeuft. -->
+		<!-- Gleiche Auszeichnung wie Abbrechen/Speichern.
+	     Bewusst ein a und kein button: Ein button im Formular wuerde beim Klick
+	     absenden und damit das Plugin neu starten. -->
 		<div class="cc-diag-reset-zeile">
 			<a href="#" id="btnresetstats" data-role="button" data-inline="true"
 				data-mini="true" data-icon="refresh">Statistik zurücksetzen</a>

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -101,22 +101,9 @@ $psubfolder =~ s/(.*)\/(.*)\/(.*)$/$2/g;
 if ( $cgi->param('ajax_status') || $cgi->url_param('ajax_status') ) {
 	my ($status_text, $status_class, $diagnostics, $status_daten) = getStatus($psubfolder);
 	print $cgi->header( -type => 'application/json', -charset => 'utf-8' );
-	# NOTE: encode_json() (and JSON::PP->new with the default utf8(1)) expects a
-	# proper Perl-internal Unicode string and UTF-8-*encodes* it. This script has
-	# no "use utf8;" pragma, so string literals like "Läuft" are just the raw
-	# UTF-8 *bytes* from the source file (each byte already its own "char", no
-	# Unicode flag) - exactly like everywhere else in this script, where that's
-	# fine because the bytes get printed through unchanged. encode_json() doesn't
-	# know that though: it takes those raw bytes and UTF-8-encodes them *again*,
-	# double-encoding every umlaut (e.g. "Läuft" -> "LÃ¤uft" in the browser).
-	# utf8(0) tells JSON::PP the strings are already the bytes we want in the
-	# output - it only handles the JSON structure (quotes, braces, escaping) and
-	# passes string content through untouched, consistent with how the rest of
-	# this script (and the HTML::Template output) already handles UTF-8.
-	# Sensorwerte separat: Die Tabelle wird BEWUSST nicht bei jedem Abruf neu
-	# gebaut und ersetzt - das würde Haken und Eingaben zerstören, die gerade
-	# bearbeitet, aber noch nicht gespeichert wurden. Stattdessen kommen nur die
-	# Werte, und das JS schreibt sie in die jeweilige Zelle.
+	# utf8(0) statt der Voreinstellung: Diese Datei hat kein "use utf8", die
+	# Zeichenketten liegen also bereits als UTF-8-Bytes vor. Ohne diese Angabe
+	# wuerde JSON::PP sie ein zweites Mal kodieren - aus "Läuft" wird "LÃ¤uft".
 	my $werte = {};
 	if ($status_daten && ref($status_daten->{werte}) eq 'HASH') {
 		for my $pdid (keys %{ $status_daten->{werte} }) {
@@ -519,40 +506,10 @@ sub form
 }
 
 #####################################################
-# Status-Sub - liest die Heartbeat-Datei, die cfc.py auf der Ramdisk schreibt.
+# Liest die Statusdatei und leitet daraus den Anzeigetext ab.
 #
-# Prüfreihenfolge (jede Stufe schwerwiegender als eine reine "Warnung"):
-#   1. Statusdatei fehlt komplett             -> Plugin läuft nicht
-#   2. !sensors_ready                          -> Registriere Sensoren. Gilt fuer die
-#                                                 allererste Startphase genauso wie
-#                                                 fuer jeden spaeteren Reconnect
-#                                                 mitten im Betrieb (siehe
-#                                                 comfoconnect.py: sensors_ready).
-#   3. MQTT getrennt                          -> kann ohnehin nichts liefern
-#   4. last_alive_ping zu alt (>30s)          -> Verbindungs-Thread tot/hängt
-#   5. last_sensor_data aelter als der         -> Verbindung/Thread laufen zwar noch,
-#      eingestellte Wert, obwohl Sensoren         aber die Anlage schickt nichts mehr.
-#      registriert sind UND die Ueberwachung      Der Prozess "lebt" (alive_ping bleibt
-#      eingeschaltet ist                          frisch, weil die Leseschleife einfach
-#                                                 weiterdreht) und Keepalives werden
-#                                                 beantwortet - ohne diese Pruefung
-#                                                 saehe das faelschlich wie "laeuft
-#                                                 einwandfrei" aus. Ist die Ueberwachung
-#                                                 nicht aktiviert, wird hier bewusst gar
-#                                                 nichts ausgewertet und der Status
-#                                                 bleibt unveraendert.
-#   6. Alles obige unauffällig                 -> Laeuft, X Sensoren + Alter der zuletzt
-#                                                 empfangenen Sensordaten. Das Alter ist
-#                                                 der eigentliche Lebensbeweis: eine
-#                                                 statische Meldung wie "X Sensoren
-#                                                 registriert" sieht auch dann noch gut
-#                                                 aus, wenn laengst nichts mehr fliesst.
-#                                                 Wurden Sensoren uebersprungen (von
-#                                                 dieser Anlage nicht unterstuetzt),
-#                                                 erscheint "X von Y" als Warnung.
-#
-# Genutzt sowohl beim initialen Seitenaufbau (sub form) als auch vom
-# AJAX-Status-Endpoint ganz oben, den main.html per JS periodisch abfragt.
+# Liefert (Text, CSS-Klasse, Diagnose-HTML, Rohdaten). Die Rohdaten geben
+# Sensor- und Befehlstabelle weiter, damit die Datei nur einmal geoeffnet wird.
 #####################################################
 
 sub getStatus
@@ -625,18 +582,10 @@ sub getStatus
 					$status_text = "Gestört - seit über ${watch_timeout}s keine Sensordaten mehr empfangen";
 					$status_class = "cc-status-error";
 				} else {
-					# Alter der letzten Sensordaten mit anzeigen: eine reine
-					# "X Sensoren registriert"-Meldung steht auch dann noch unveraendert
-					# da, wenn seit Minuten nichts mehr ankommt. Der mitlaufende Zaehler
-					# (Seite pollt jede Sekunde) ist der sichtbare Lebensbeweis - und er
-					# ist auch dann da, wenn die Ueberwachung ausgeschaltet ist, nur eben
-					# ohne dass daraus jemals eine Stoerung wird.
-					#
-					# Wurden Sensoren uebersprungen, wird das als Warnung angezeigt statt
-					# als Fehler: nicht jede Anlage und nicht jeder Firmware-Stand kennt
-					# alle bekannten Messwerte, das ist der Normalfall und kein Defekt.
-					# Sichtbar sein soll es trotzdem - sonst wundert man sich, warum ein
-					# erwarteter Wert in Loxone fehlt.
+					# Alter der letzten Daten mit anzeigen - eine reine Zahl aktiver Sensoren
+					# stuende auch dann noch da, wenn seit Minuten nichts mehr ankommt.
+					# Uebersprungene Sensoren gelten als Warnung, nicht als Fehler: Nicht jede
+					# Anlage kennt jeden Messwert.
 					if ($sensors_exp > 0 && $sensors_reg < $sensors_exp) {
 						$status_text = "Läuft - $sensors_reg von $sensors_exp Sensoren aktiv";
 						$status_class = "cc-status-warn";
@@ -661,17 +610,8 @@ sub getStatus
 }
 
 #####################################################
-# Alter in lesbarer Form: unter einer Sekunde in Millisekunden ("vor 340ms"),
-# darueber in ganzen Sekunden ("vor 12s") bzw. ab einer Minute als "vor 3m 05s".
-#
-# Der uebergebene Wert ist eine Fliesskommazahl (siehe getStatus) - deshalb
-# ueberall explizit runden bzw. abschneiden. Ohne das erschiene im Normalbetrieb,
-# wo die Werte im Sekundenbruchteil-Bereich liegen, eine Zahl mit einem Dutzend
-# Nachkommastellen.
-#
-# Negative Werte sind moeglich, wenn die Uhr zwischen dem Schreiben der
-# Statusdatei und dem Lesen hier minimal zurueckspringt (NTP) - dann auf 0
-# klemmen statt ein unsinniges "vor -1s" anzuzeigen.
+# Kleines Alter lesbar formatieren: Millisekunden, Sekunden, ab einer Minute
+# "vor 3m 05s".
 #####################################################
 
 sub getDiagnostics
@@ -774,17 +714,10 @@ sub getDiagnostics
 }
 
 #####################################################
-# Den mitgelieferten Sensorkatalog aus bin/mqtt_data.py lesen.
+# Liest den Sensorkatalog aus bin/mqtt_data.py.
 #
-# Ja, das ist eine Python-Datei, die hier mit einem regulären Ausdruck gelesen
-# wird - und normalerweise wäre das eine schlechte Idee. Hier ist es vertretbar:
-# Die Datei gehört zum Plugin, hat ein streng gleichförmiges Format, und die
-# Alternative wäre gewesen, den Katalog zusätzlich in einer zweiten Datei zu
-# führen. Zwei Quellen, die auseinanderlaufen können, wären der größere Schaden.
-#
-# Bewusst NICHT aus der Statusdatei: Die Sensortabelle muss sich auch dann
-# bedienen lassen, wenn das Plugin gerade nicht läuft - gerade dann will man
-# vielleicht etwas abwählen.
+# Bewusst aus der Datei und nicht aus der Statusdatei: Die Tabelle muss sich
+# auch bedienen lassen, wenn das Plugin gerade nicht laeuft.
 #####################################################
 
 sub readSensorCatalog
@@ -826,11 +759,10 @@ sub readSensorCatalog
 }
 
 #####################################################
-# Die Sensortabelle aufbauen.
+# Baut die Sensortabelle, nach Gruppen gegliedert.
 #
 # Liefert (html, anzahl_aktiv, anzahl_gesamt) - die beiden Zahlen stehen im
-# zugeklappten Zustand in der Kopfzeile, damit man ohne Aufklappen sieht, wie
-# viele Sensoren überhaupt aktiv sind.
+# zugeklappten Zustand in der Kopfzeile.
 #####################################################
 
 sub getSensorTable
@@ -930,19 +862,13 @@ sub getSensorTable
 }
 
 #####################################################
-# Befehlstabelle: alle Themen, die das Plugin entgegennimmt, mit dem zuletzt
-# darauf empfangenen Wert.
+# Baut die Befehlstabelle: alle Topics mit zulaessigen Werten, Bedeutung und
+# dem zuletzt darauf empfangenen Wert.
 #
-# Der Katalog steht bewusst HIER und nicht in einer eigenen Datei neben
-# mqtt_data.py. Eine solche Datei wuerde eine Erweiterbarkeit vortaeuschen, die es
-# nicht gibt: Was ein Befehl tatsaechlich an die Anlage schickt, steht in
-# _dispatch_message() in cfc.py (46 Zweige, rund 340 Zeilen). Ein Eintrag allein
-# wuerde abonniert, angezeigt - und taete nichts.
-#
-# Angezeigt wird zusaetzlich der zuletzt empfangene Wert. Das beantwortet die
-# haeufigste Frage beim Einrichten ("kommt mein Befehl aus Loxone hier ueberhaupt
-# an?") und macht Tippfehler im Themennamen sichtbar, weil daneben die gueltige
-# Schreibweise steht.
+# Der Katalog steht hier und nicht in einer eigenen Datei - was ein Befehl
+# bewirkt, liegt in _dispatch_message() und laesst sich nicht als Daten
+# ablegen. Eine eigene Datei taeuschte eine Erweiterbarkeit vor, die es nicht
+# gibt.
 #####################################################
 
 sub getCommandTable
@@ -1119,24 +1045,12 @@ my @COMMANDS = (
 }
 
 #####################################################
-# "Wie lange ist das her" in grober, lesbarer Form.
-#
-# Getrennt von formatAge(): Das dort ist auf den Sekundenbereich ausgelegt
-# (Altersanzeige der Sensordaten, im Normalbetrieb Millisekunden). Für Ereignisse,
-# die auch Tage zurückliegen können, käme dort "vor 2880m 00s" heraus - formal
-# richtig, aber niemand rechnet das im Kopf in zwei Tage um.
+# Formatiert eine Zeitspanne grob lesbar ("vor 6m", "vor 2 Tagen").
 #####################################################
 
 #####################################################
-# Genauer Zeitpunkt, so geschrieben wie im Logfile.
-#
-# Das Log stellt jeder Zeile "HH:MM:SS.mmm" voran. Eine Angabe wie "vor 6m" ist
-# zwar griffig, zwingt beim Nachschlagen aber zum Kopfrechnen - und danach sucht
-# man im Log trotzdem nach einer Uhrzeit. Deshalb wird beides gezeigt: die Uhrzeit
-# zum Auffinden, die Spanne zum Einordnen.
-#
-# Liegt der Zeitpunkt nicht am heutigen Tag, kommt das Datum davor - sonst führte
-# "08:14:02" bei einem drei Tage alten Eintrag in die Irre.
+# Formatiert einen Zeitpunkt wie im Logfile (HH:MM:SS), mit Datum davor, wenn
+# er nicht vom heutigen Tag stammt.
 #####################################################
 
 sub formatZeitpunkt


### PR DESCRIPTION
Zeitvorgaben auf 4 Byte — 24-Stunden-Boost war unmöglich, an deiner Anlage bestätigt. Bytefolge für bestehende Werte beweisbar unverändert.

Wirksame Zeiten in der Oberfläche, weil Loxone nur bei Änderung sendet.

Zeilen gegenüber Gruppenüberschriften eingerückt, Spaltenbreiten der Befehlstabelle korrigiert.

Kommentare in allen vier Dateien vereinheitlicht — durchgehend deutsch, beschreiben das Verhalten statt der Entstehungsgeschichte. 20 Docstrings, 35 englische Blöcke, dazu index.cgi und main.html. Gegengeprüft, dass der Code dabei Token für Token unverändert blieb.